### PR TITLE
Fix test failure because of failed name resolution

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # pandoc needed for docu, see https://nbsphinx.readthedocs.io/en/0.7.1/installation.html?highlight=pandoc#pandoc
       - name: Install Non-Python Packages
-        run: sudo apt-get update -yq && sudo apt-get -yq install pandoc
+        run: apt-get update -yq && apt-get -yq install pandoc
       - uses: actions/checkout@v2.3.1
         with:
           fetch-depth: 0

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -18,7 +18,7 @@ jobs:
     # This is needed to enable host name resolution for the minio service from the tests
     #https://docs.github.com/en/actions/using-containerized-services/about-service-containers#mapping-docker-host-and-service-container-ports
     # https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers#running-jobs-in-containers
-    container: python:3.8-buster-slim
+    container: python:3.8-slim-buster
     services:
       remote-storage:
         image: bitnami/minio:latest

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # pandoc needed for docu, see https://nbsphinx.readthedocs.io/en/0.7.1/installation.html?highlight=pandoc#pandoc
       - name: Install Non-Python Packages
-        run: apt-get update -yq && apt-get -yq install pandoc
+        run: apt-get update -yq && apt-get -yq install pandoc git
       - uses: actions/checkout@v2.3.1
         with:
           fetch-depth: 0

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # pandoc needed for docu, see https://nbsphinx.readthedocs.io/en/0.7.1/installation.html?highlight=pandoc#pandoc
       - name: Install Non-Python Packages
-        run: apt-get update -yq && apt-get -yq install pandoc git
+        run: apt-get update -yq && apt-get -yq install pandoc git git-lfs
       - uses: actions/checkout@v2.3.1
         with:
           fetch-depth: 0

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -15,7 +15,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    # This is needed to enable host name resolution for the minio service from the tests
+    #https://docs.github.com/en/actions/using-containerized-services/about-service-containers#mapping-docker-host-and-service-container-ports
+    # https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers#running-jobs-in-containers
+    container: python:3.8-buster-slim
     services:
       remote-storage:
         image: bitnami/minio:latest


### PR DESCRIPTION
This PR fixes the test failure related to failed name resolution on CI.
It makes the tests run inside a container because this is apparently needed to enable host name resolution for the minio service from within the tests.

You can refer to these links for more information:
- https://docs.github.com/en/actions/using-containerized-services/about-service-containers#mapping-docker-host-and-service-container-ports
- https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers#running-jobs-in-containers