### PR TITLE
Pyyaml version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.18.4
-apache-libcloud~=3.7.0
-tqdm>=4.48.2
-pyyaml~=6.0.1
+numpy==1.18.4
+apache-libcloud==3.7.0
+tqdm==4.48.2
+pyyaml==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.18.4
 apache-libcloud~=3.7.0
 tqdm>=4.48.2
-pyyaml~=5.4.1
+pyyaml~=6.0.1


### PR DESCRIPTION
Pyyaml version bump because pyyaml <6.0.0 is incompatible with cython 3 (see [here](https://github.com/yaml/pyyaml/issues/724))